### PR TITLE
Use Wiremock v2.17

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Installation
 It easiest to install wiremock-php via Composer:
 
 ```bash
-php composer.phar require --dev wiremock-php/wiremock-php:1.43.1
+php composer.phar require --dev wiremock-php/wiremock-php:2.17.1
 ```
 
 Usage

--- a/src/WireMock/Client/Curl.php
+++ b/src/WireMock/Client/Curl.php
@@ -32,4 +32,25 @@ class Curl
 
         return $result;
     }
+
+    /**
+     * @param string $url
+     * @return mixed
+     */
+    public function delete($url)
+    {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            "Content-Length: 0",
+        ]);
+
+        $result = curl_exec($ch);
+
+        curl_close($ch);
+
+        return $result;
+    }
 }

--- a/src/WireMock/Client/JsonValueMatchingStrategy.php
+++ b/src/WireMock/Client/JsonValueMatchingStrategy.php
@@ -20,7 +20,25 @@ class JsonValueMatchingStrategy extends ValueMatchingStrategy
     public function toArray()
     {
         $array = parent::toArray();
-        $array['jsonCompareMode'] = $this->_jsonCompareMode;
+
+        switch ($this->_jsonCompareMode) {
+            case self::COMPARE_MODE__NON_EXTENSIBLE:
+                $array['ignoreArrayOrder'] = true;
+                $array['ignoreExtraElements'] = true;
+                break;
+            case self::COMPARE_MODE__LENIENT:
+                $array['ignoreArrayOrder'] = true;
+                $array['ignoreExtraElements'] = false;
+                break;
+            case self::COMPARE_MODE__STRICT:
+                $array['ignoreArrayOrder'] = false;
+                $array['ignoreExtraElements'] = true;
+                break;
+            case self::COMPARE_MODE__STRICT_ORDER:
+                $array['ignoreArrayOrder'] = false;
+                $array['ignoreExtraElements'] = false;
+                break;
+        }
         return $array;
     }
 }

--- a/src/WireMock/Client/RequestPatternBuilder.php
+++ b/src/WireMock/Client/RequestPatternBuilder.php
@@ -10,6 +10,7 @@ class RequestPatternBuilder
     private $_method;
     private $_urlMatchingStrategy;
     private $_headers = array();
+    private $_queryParameters = array();
     private $_bodyPatterns = array();
 
     /**
@@ -44,6 +45,17 @@ class RequestPatternBuilder
     }
 
     /**
+     * @param string $name
+     * @param ValueMatchingStrategy $valueMatchingStrategy
+     * @return RequestPatternBuilder
+     */
+    public function withQueryParameter($name, ValueMatchingStrategy $valueMatchingStrategy)
+    {
+        $this->_queryParameters[$name] = $valueMatchingStrategy->toArray();
+        return $this;
+    }
+
+    /**
      * @param ValueMatchingStrategy $valueMatchingStrategy
      * @return RequestPatternBuilder
      */
@@ -64,6 +76,9 @@ class RequestPatternBuilder
         }
         if (!empty($this->_bodyPatterns)) {
             $requestPattern->setBodyPatterns($this->_bodyPatterns);
+        }
+        if (!empty($this->_queryParameters)) {
+            $requestPattern->setQueryParameters($this->_queryParameters);
         }
         return $requestPattern;
     }

--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -109,16 +109,16 @@ class WireMock
         $this->_curl->post($url, array('fixedDelay' => $delayMillis));
     }
 
-    public function addRequestProcessingDelay($delayMillis)
-    {
-        $url = $this->_makeUrl('__admin/socket-delay');
-        $this->_curl->post($url, array('milliseconds' => $delayMillis));
-    }
-
     public function saveAllMappings()
     {
         $url = $this->_makeUrl('__admin/mappings/save');
         $this->_curl->post($url);
+    }
+
+    public function deleteMappings($id)
+    {
+        $url = $this->_makeUrl('__admin/mappings/' . $id);
+        $this->_curl->delete($url);
     }
 
     /**

--- a/src/WireMock/Matching/RequestPattern.php
+++ b/src/WireMock/Matching/RequestPattern.php
@@ -7,6 +7,7 @@ class RequestPattern
     private $_method;
     private $_urlMatchingStrategy;
     private $_headers;
+    private $_queryParameters;
     private $_bodyPatterns;
     private $_priority;
 
@@ -25,6 +26,11 @@ class RequestPattern
         $this->_headers = $headers;
     }
 
+    public function setQueryParameters(array $queryParameters)
+    {
+        $this->_queryParameters = $queryParameters;
+    }
+
     public function setBodyPatterns(array $bodyPatterns)
     {
         $this->_bodyPatterns = $bodyPatterns;
@@ -36,6 +42,9 @@ class RequestPattern
         $array = array_merge($array, $this->_urlMatchingStrategy->toArray());
         if ($this->_headers) {
             $array['headers'] = $this->_headers;
+        }
+        if ($this->_queryParameters) {
+            $array['queryParameters'] = $this->_queryParameters;
         }
         if ($this->_bodyPatterns) {
             $array['bodyPatterns'] = $this->_bodyPatterns;

--- a/test/WireMock/Integration/FaultsAndDelaysIntegrationTest.php
+++ b/test/WireMock/Integration/FaultsAndDelaysIntegrationTest.php
@@ -39,20 +39,6 @@ class FaultsAndDelaysIntegrationTest extends WireMockIntegrationTest
         assertThat($this->_testClient->getLastRequestTimeMillis(), greaterThan(1000));
     }
 
-    public function testGlobalFixedDelayOnSocketAcceptanceCanBeSet()
-    {
-        // given
-        $this->_testClient->get('/not/stubbed/url');
-        assertThat($this->_testClient->getLastRequestTimeMillis(), lessThan(1000));
-
-        // when
-        self::$_wireMock->addRequestProcessingDelay(1000);
-        $this->_testClient->get('/not/stubbed/url');
-
-        // then
-        assertThat($this->_testClient->getLastRequestTimeMillis(), greaterThan(1000));
-    }
-
     public function testEmptyResponseFaultCanBeStubbed()
     {
         $this->_testFaultCanBeStubbed(Fault::EMPTY_RESPONSE);

--- a/test/WireMock/Integration/MappingsAssertionFunctions.php
+++ b/test/WireMock/Integration/MappingsAssertionFunctions.php
@@ -6,6 +6,9 @@ function assertThatTheOnlyMappingPresentIs(StubMapping $stubMapping)
 {
     $mappings = getMappings();
     assertThat($mappings, is(arrayWithSize(1)));
+
+    unset($mappings[0]['id']);
+    unset($mappings[0]['uuid']);
     assertThat($mappings[0], is($stubMapping->toArray()));
 }
 

--- a/test/WireMock/Integration/VerificationIntegrationTest.php
+++ b/test/WireMock/Integration/VerificationIntegrationTest.php
@@ -73,6 +73,42 @@ class VerificationIntegrationTest extends WireMockIntegrationTest
             ->withoutHeader('Cookie'));
     }
 
+    public function testCanVerifyRequestWithQuery()
+    {
+        // given
+        $this->_testClient->get('/some/url?foo=bar');
+
+        // when
+        self::$_wireMock->verify(WireMock::getRequestedFor(WireMock::urlMatching('/some/url.*'))
+            ->withQueryParameter('foo', WireMock::equalTo('bar')));
+    }
+
+    /**
+     * @expectedException \WireMock\Client\VerificationException
+     */
+    public function testVerifyingWiremockUrlEqualThrowsException()
+    {
+        // given
+        $this->_testClient->get('/some/url?foo=bar');
+
+        // when
+        self::$_wireMock->verify(WireMock::getRequestedFor(WireMock::urlEqualTo('/some/url'))
+            ->withQueryParameter('foo', WireMock::equalTo('bar')));
+    }
+
+    /**
+     * @expectedException \WireMock\Client\VerificationException
+     */
+    public function testVerifyingRequestWithMissingQueryThrowsException()
+    {
+        // given
+        $this->_testClient->get('/some/url');
+
+        // when
+        self::$_wireMock->verify(WireMock::getRequestedFor(WireMock::urlEqualTo('/some/url'))
+            ->withQueryParameter('foo', WireMock::equalTo('bar')));
+    }
+
     public function testCanVerifyRequestHasBody()
     {
         // given

--- a/wiremock/start.sh
+++ b/wiremock/start.sh
@@ -13,7 +13,7 @@ fi
 # Download the wiremock jar if we need it
 if ! [ -e wiremock-standalone.jar ]; then
     echo WireMock standalone JAR missing. Downloading.
-    curl http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock/1.43/wiremock-1.43-standalone.jar -o wiremock-standalone.jar
+    curl http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.17.0/wiremock-standalone-2.17.0.jar -o wiremock-standalone.jar
     status=$?
     if [ ${status} -ne 0 ]; then
         echo curl could not download WireMock JAR 1>&2


### PR DESCRIPTION
- upgrade to wiremock v2.17
- add queryParameters matching
- change JsonValueMatching
- remove unsupported 'socket-delay'