### PR TITLE
withQueryParam for MappingBuilder

### DIFF
--- a/src/WireMock/Client/MappingBuilder.php
+++ b/src/WireMock/Client/MappingBuilder.php
@@ -15,6 +15,8 @@ class MappingBuilder
     private $_responseDefinitionBuilder;
     /** @var array of string -> ValueMatchingStrategy */
     private $_headers = array();
+    /** @var array of string -> ValueMatchingStrategy */
+    private $_queryParams = array();
     /** @var array of ValueMatchingStrategy */
     private $_requestBodyPatterns = array();
     /** @var int */
@@ -70,6 +72,17 @@ class MappingBuilder
     }
 
     /**
+     * @param $paramName
+     * @param ValueMatchingStrategy $valueMatchingStrategy
+     * @return MappingBuilder
+     */
+    public function withQueryParam($paramName, ValueMatchingStrategy $valueMatchingStrategy)
+    {
+        $this->_queryParams[$paramName] = $valueMatchingStrategy->toArray();
+        return $this;
+    }
+
+    /**
      * @param ValueMatchingStrategy $valueMatchingStrategy
      * @return MappingBuilder
      */
@@ -113,6 +126,7 @@ class MappingBuilder
     {
         $responseDefinition = $this->_responseDefinitionBuilder->build();
         $this->_requestPattern->setHeaders($this->_headers);
+        $this->_requestPattern->setQueryParameters($this->_queryParams);
         if (!empty($this->_requestBodyPatterns)) {
             $this->_requestPattern->setBodyPatterns($this->_requestBodyPatterns);
         }

--- a/test/WireMock/Client/MappingBuilderTest.php
+++ b/test/WireMock/Client/MappingBuilderTest.php
@@ -62,6 +62,21 @@ class MappingBuilderTest extends \PHPUnit_Framework_TestCase
         verify($this->_mockRequestPattern)->setHeaders($headers);
     }
 
+    public function testMatchedRequestQueryParamsAreSetOnRequestPattern()
+    {
+        // given
+        $mappingBuilder = new MappingBuilder($this->_mockRequestPattern);
+        $mappingBuilder->willReturn($this->_mockResponseDefinitionBuilder);
+
+        // when
+        $mappingBuilder->withQueryParam('aQueryParam', new ValueMatchingStrategy('equalTo', 'aValue'));
+        $mappingBuilder->build();
+
+        // then
+        $headers = array('aQueryParam' => array('equalTo' => 'aValue'));
+        verify($this->_mockRequestPattern)->setQueryParameters($headers);
+    }
+
     public function testRequestBodyMatcherIsSetOnRequestPattern()
     {
         // given


### PR DESCRIPTION
In previous PR I forgot to add `withQueryParam` into `MappingBuilder`.