### PR TITLE
Matching json path cat use another matchnig strategy

### DIFF
--- a/src/WireMock/Client/JsonPathMatchingStrategy.php
+++ b/src/WireMock/Client/JsonPathMatchingStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WireMock\Client;
+
+class JsonPathMatchingStrategy extends ValueMatchingStrategy
+{
+    public function __construct($jsonPath, ValueMatchingStrategy $matchingStrategy)
+    {
+        $body = $jsonPath;
+        if ($matchingStrategy) {
+            $body = $matchingStrategy->toArray();
+            $body['expression'] = $jsonPath;
+        }
+
+        parent::__construct('matchesJsonPath', $body);
+    }
+}

--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -435,11 +435,12 @@ class WireMock
 
     /**
      * @param string $jsonPath
+     * @param ValueMatchingStrategy|null $matchingStrategy
      * @return ValueMatchingStrategy
      */
-    public static function matchingJsonPath($jsonPath)
+    public static function matchingJsonPath($jsonPath, ValueMatchingStrategy $matchingStrategy = null)
     {
-        return new ValueMatchingStrategy('matchesJsonPath', $jsonPath);
+        return new JsonPathMatchingStrategy($jsonPath, $matchingStrategy);
     }
 
     public static function matchingXPath($xPath)


### PR DESCRIPTION
Change matchingJsonPath function to support this feature:
`
"bodyPatterns" : [ {
      "matchesJsonPath" : {
         "expression": "$.outer",
         "equalToJson": "{ \"inner\": 42 }"
      }
} ]
`