### PR TITLE
Json matching strategy like wiremock api

### DIFF
--- a/src/WireMock/Client/JsonValueMatchingStrategy.php
+++ b/src/WireMock/Client/JsonValueMatchingStrategy.php
@@ -4,41 +4,21 @@ namespace WireMock\Client;
 
 class JsonValueMatchingStrategy extends ValueMatchingStrategy
 {
-    const COMPARE_MODE__NON_EXTENSIBLE = 'NON_EXTENSIBLE';
-    const COMPARE_MODE__LENIENT = 'LENIENT';
-    const COMPARE_MODE__STRICT = 'STRICT';
-    const COMPARE_MODE__STRICT_ORDER = 'STRICT_ORDER';
+    private $_ignoreArrayOrder;
+    private $_ignoreExtraElements;
 
-    private $_jsonCompareMode;
-
-    public function __construct($matchingValue, $jsonCompareMode)
+    public function __construct($matchingValue, $ignoreArrayOrder = true, $ignoreExtraElements = true)
     {
         parent::__construct('equalToJson', $matchingValue);
-        $this->_jsonCompareMode = $jsonCompareMode;
+        $this->_ignoreArrayOrder = $ignoreArrayOrder;
+        $this->_ignoreExtraElements = $ignoreExtraElements;
     }
 
     public function toArray()
     {
         $array = parent::toArray();
-
-        switch ($this->_jsonCompareMode) {
-            case self::COMPARE_MODE__NON_EXTENSIBLE:
-                $array['ignoreArrayOrder'] = true;
-                $array['ignoreExtraElements'] = true;
-                break;
-            case self::COMPARE_MODE__LENIENT:
-                $array['ignoreArrayOrder'] = true;
-                $array['ignoreExtraElements'] = false;
-                break;
-            case self::COMPARE_MODE__STRICT:
-                $array['ignoreArrayOrder'] = false;
-                $array['ignoreExtraElements'] = true;
-                break;
-            case self::COMPARE_MODE__STRICT_ORDER:
-                $array['ignoreArrayOrder'] = false;
-                $array['ignoreExtraElements'] = false;
-                break;
-        }
+        $array['ignoreArrayOrder'] = $this->_ignoreArrayOrder;
+        $array['ignoreExtraElements'] = $this->_ignoreExtraElements;
         return $array;
     }
 }

--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -425,12 +425,13 @@ class WireMock
 
     /**
      * @param string $value
-     * @param string $jsonCompareMode
+     * @param bool $ignoreArrayOrder
+     * @param bool $ignoreExtraElements
      * @return ValueMatchingStrategy
      */
-    public static function equalToJson($value, $jsonCompareMode = JsonValueMatchingStrategy::COMPARE_MODE__NON_EXTENSIBLE)
+    public static function equalToJson($value, $ignoreArrayOrder = true, $ignoreExtraElements = true)
     {
-        return new JsonValueMatchingStrategy($value, $jsonCompareMode);
+        return new JsonValueMatchingStrategy($value, $ignoreArrayOrder, $ignoreExtraElements);
     }
 
     /**

--- a/test/WireMock/Integration/StubbingIntegrationTest.php
+++ b/test/WireMock/Integration/StubbingIntegrationTest.php
@@ -180,7 +180,7 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // when
         $stubMapping = self::$_wireMock->stubFor(WireMock::get(WireMock::urlEqualTo('/some/url'))
             ->withRequestBody(WireMock::equalToJson('{"key":"value"}'))
-            ->withRequestBody(WireMock::equalToJson('{}', JsonValueMatchingStrategy::COMPARE_MODE__LENIENT))
+            ->withRequestBody(WireMock::equalToJson('{}', true, true))
             ->willReturn(WireMock::aResponse()));
 
         // then


### PR DESCRIPTION
Use two flags instead JsonValueMatchingStrategy consts:
`equalToJson($val, true, true)` instead `equalToJson($val, JsonValueMatchingStrategy::COMPARE_MODE__NON_EXTENSIBLE)`
