### PR TITLE
Fix undefined index when pattern is not valid

### DIFF
--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -158,7 +158,7 @@ class WireMock
         $url = $this->_makeUrl('__admin/requests/find');
         $findResultJson = $this->_curl->post($url, $requestPattern->toArray());
         $findResultArray = json_decode($findResultJson, true);
-        $requestArrays = $findResultArray['requests'];
+        $requestArrays = isset($findResultArray['requests']) ? $findResultArray['requests'] : [];
         $requests = array();
         foreach ($requestArrays as $responseArray) {
             $requests[] = new LoggedRequest($responseArray);


### PR DESCRIPTION
When the pattern is occasionally not valid then request is successful, but there is no `requests` field in response, but `errors`. In this case PHP will get you `undefined index "requests"` notice.