### PR TITLE
Update HttpWait for PHP 8.2 support

### DIFF
--- a/src/WireMock/Client/HttpWait.php
+++ b/src/WireMock/Client/HttpWait.php
@@ -26,7 +26,7 @@ class HttpWait
                 } else if (!isset($headers[0])) {
                     $debugTrace[] = "$url not yet up. \$headers[0] not set";
                 } else {
-                    $debugTrace[] = "$url not yet up. \$headers[0] was ${headers[0]}";
+                    $debugTrace[] = "$url not yet up. \$headers[0] was {$headers[0]}";
                 }
             }
             usleep(100000);


### PR DESCRIPTION
Fix PHP 8.2 deprecation error: "Deprecation Notice: Using ${var} in strings is deprecated, use {$var} instead"