### PR TITLE
Add authentication support for WireMock Cloud (wiremock.io)

### DIFF
--- a/src/WireMock/Client/Authentication/Authenticator.php
+++ b/src/WireMock/Client/Authentication/Authenticator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WireMock\Client\Authentication;
+
+interface Authenticator
+{
+    /**
+     * @param list<non-empty-string> $headers
+     * @return list<non-empty-string>
+     */
+    public function modifyHeaders(array $headers): array;
+
+    /**
+     * @param non-empty-string $url
+     * @return non-empty-string
+     */
+    public function modifyUrl(string $url): string;
+}

--- a/src/WireMock/Client/Authentication/NullAuthenticator.php
+++ b/src/WireMock/Client/Authentication/NullAuthenticator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WireMock\Client\Authentication;
+
+final class NullAuthenticator implements Authenticator
+{
+    public function modifyHeaders(array $headers): array
+    {
+        return $headers;
+    }
+
+    public function modifyUrl(string $url): string
+    {
+        return $url;
+    }
+}

--- a/src/WireMock/Client/Authentication/TokenAuthenticator.php
+++ b/src/WireMock/Client/Authentication/TokenAuthenticator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WireMock\Client\Authentication;
+
+final class TokenAuthenticator implements Authenticator
+{
+    /**
+     * @var non-empty-string
+     */
+    private $token;
+
+    /**
+     * @param non-empty-string $token
+     */
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    public function modifyHeaders(array $headers): array
+    {
+        return array_merge($headers, [sprintf('Authorization: Token %s', $this->token)]);
+    }
+
+    public function modifyUrl(string $url): string
+    {
+        return $url;
+    }
+}

--- a/src/WireMock/Client/HttpWait.php
+++ b/src/WireMock/Client/HttpWait.php
@@ -4,6 +4,16 @@ namespace WireMock\Client;
 
 class HttpWait
 {
+    /**
+     * @var Curl
+     */
+    private $curl;
+
+    public function __construct(?Curl $curl = null)
+    {
+        $this->curl = $curl ?? new Curl();
+    }
+
     public function waitForServerToGive200($url, $timeoutSecs = 10, $debug = true)
     {
         $debugTrace = array();
@@ -11,26 +21,18 @@ class HttpWait
         $serverStarted = false;
         while (microtime(true) - $startTime < $timeoutSecs) {
             try {
-                $headers = @get_headers($url, 1);
-            } catch (\Exception $e) {
-                $debugTrace[] = "$url not yet up. Error getting headers: " . $e->getMessage();
-                continue;
-            }
-
-            if (isset($headers) && isset($headers[0]) && strpos($headers[0], '200 OK') !== false) {
+                $this->curl->get($url);
                 $serverStarted = true;
                 break;
-            } else {
-                if (!isset($headers)) {
-                    $debugTrace[] = "$url not yet up. \$headers not set";
-                } else if (!isset($headers[0])) {
-                    $debugTrace[] = "$url not yet up. \$headers[0] not set";
-                } else {
-                    $debugTrace[] = "$url not yet up. \$headers[0] was {$headers[0]}";
-                }
+            } catch (\Exception $e) {
+                $debugTrace[] = "$url not yet up. " . $e->getMessage();
+
+                usleep(100000);
+
+                continue;
             }
-            usleep(100000);
         }
+
         if (!$serverStarted) {
             $time = microtime(true) - $startTime;
             if ($debug) {

--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -23,6 +23,8 @@ class WireMock
     private $hostname;
     /** @var int */
     private $port;
+    /** @var string */
+    private $scheme;
     /** @var HttpWait */
     private $httpWait;
     /** @var Curl  */
@@ -44,13 +46,15 @@ class WireMock
         Curl $curl,
         Serializer $serializer,
         $hostname = 'localhost',
-        $port = 8080
+        $port = 8080,
+        $scheme = 'http'
     ) {
-        $this->hostname = $hostname;
-        $this->port = $port;
         $this->httpWait = $httpWait;
         $this->curl = $curl;
         $this->serializer = $serializer;
+        $this->hostname = $hostname;
+        $this->port = $port;
+        $this->scheme = $scheme;
     }
 
     public function isAlive($timeoutSecs = 10, $debug = true)
@@ -505,9 +509,9 @@ class WireMock
         }
     }
 
-    private function _makeUrl($path)
+    private function _makeUrl($path): string
     {
-        return "http://$this->hostname:$this->port/$path";
+        return sprintf('%s://%s:%d/%s', $this->scheme, $this->hostname, $this->port, $path);
     }
 
     /**

--- a/test/WireMock/Integration/CloudIntegrationTest.php
+++ b/test/WireMock/Integration/CloudIntegrationTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace WireMock\Integration;
+
+use PHPUnit\Framework\TestCase;
+use WireMock\Client\Authentication\TokenAuthenticator;
+use WireMock\Client\Curl;
+use WireMock\Client\HttpWait;
+use WireMock\Client\WireMock;
+use WireMock\Serde\SerializerFactory;
+
+class CloudIntegrationTest extends TestCase
+{
+    public function testConnectToCloudHost(): void
+    {
+        $wiremockCloudHost = getenv('WIREMOCK_CLOUD_HOST');
+        $wiremockCloudToken = getenv('WIREMOCK_CLOUD_TOKEN');
+
+        if ($wiremockCloudToken === false || $wiremockCloudHost === false) {
+            self::markTestSkipped('Env variables WIREMOCK_CLOUD_HOST or WIREMOCK_CLOUD_TOKEN not set');
+        }
+
+        $curl = new Curl(new TokenAuthenticator($wiremockCloudToken));
+        $client = new WireMock(new HttpWait($curl), $curl, SerializerFactory::default(), $wiremockCloudHost, 443, 'https');
+
+        self::assertTrue($client->isAlive());
+    }
+}


### PR DESCRIPTION
Enables wiremock-php to work with wiremock.io without breaking backwards compatibility. This is how it works:

```php
$curl = new Curl(new TokenAuthenticator($token));
$client = new WireMock(new HttpWait($curl), $curl, SerializerFactory::default(), $host, 443, 'https');
```