### PR TITLE
Fix a few missing PHP 8.4 warnings

### DIFF
--- a/src/WireMock/Client/WireMock.php
+++ b/src/WireMock/Client/WireMock.php
@@ -101,7 +101,7 @@ class WireMock
      * @throws ClientException
      * @throws VerificationException
      */
-    public function verify($requestPatternBuilderOrCount, RequestPatternBuilder $requestPatternBuilder = null)
+    public function verify($requestPatternBuilderOrCount, ?RequestPatternBuilder $requestPatternBuilder = null)
     {
         if ($requestPatternBuilderOrCount instanceof CountMatchingStrategy) {
             $patternBuilder = $requestPatternBuilder;

--- a/test/WireMock/Integration/VerificationIntegrationTest.php
+++ b/test/WireMock/Integration/VerificationIntegrationTest.php
@@ -10,7 +10,7 @@ class VerificationIntegrationTest extends WireMockIntegrationTest
 {
     private $_verificationCount = 0;
 
-    private function verify($requestPatternBuilderOrCount, RequestPatternBuilder $requestPatternBuilder = null)
+    private function verify($requestPatternBuilderOrCount, ?RequestPatternBuilder $requestPatternBuilder = null)
     {
         self::$_wireMock->verify($requestPatternBuilderOrCount, $requestPatternBuilder);
         $this->_verificationCount++;
@@ -26,7 +26,7 @@ class VerificationIntegrationTest extends WireMockIntegrationTest
             $this->addToAssertionCount($this->_verificationCount);
         }
     }
-    
+
     public function testCanVerifySimpleGetToUrl()
     {
         // given
@@ -175,7 +175,7 @@ class VerificationIntegrationTest extends WireMockIntegrationTest
     {
         // then
         $this->expectException(VerificationException::class);
-        
+
         // given
         $this->_testClient->get('/some/url');
         $this->_testClient->get('/some/url');


### PR DESCRIPTION
Sorry for the spam on this repo.

I forgot to fix a few other deprecations and the reformating was applied by my IDE.

Thanks for the review :-)