### PR TITLE
Support PHP 8.5, remove deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,4 @@ workflows:
       - run_tests_and_store_logs:
           matrix:
             parameters:
-              version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+              version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']

--- a/src/WireMock/Client/Curl.php
+++ b/src/WireMock/Client/Curl.php
@@ -72,7 +72,9 @@ class Curl
             throw new ClientException($responseCode, $result);
         }
 
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $result;
     }

--- a/src/WireMock/Serde/PropNaming/ReferencingPropertyNamingStrategy.php
+++ b/src/WireMock/Serde/PropNaming/ReferencingPropertyNamingStrategy.php
@@ -48,7 +48,10 @@ class ReferencingPropertyNamingStrategy implements PropertyNamingStrategy
     function getPossibleSerializedNames(): array
     {
         $refMethod = MethodFactory::createMethod($this->possibleNamesGenerator);
-        $refMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $refMethod->setAccessible(true);
+        }
         return $refMethod->invoke(null);
     }
 }

--- a/src/WireMock/Serde/SerdeClassDiscriminationInfo.php
+++ b/src/WireMock/Serde/SerdeClassDiscriminationInfo.php
@@ -36,7 +36,10 @@ class SerdeClassDiscriminationInfo
     public function getDiscriminator(): ?ClassDiscriminator
     {
         $refMethod = MethodFactory::createMethod($this->discriminatorFactoryName);
-        $refMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $refMethod->setAccessible(true);
+        }
         return $refMethod->invoke(null);
     }
 

--- a/src/WireMock/Serde/SerdeProp.php
+++ b/src/WireMock/Serde/SerdeProp.php
@@ -70,7 +70,10 @@ class SerdeProp
     public function getData(object $object)
     {
         $refProp = new ReflectionProperty($this->owningClassName, $this->name);
-        $refProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $refProp->setAccessible(true);
+        }
         return $refProp->getValue($object);
     }
 

--- a/src/WireMock/Serde/Type/SerdeTypeClass.php
+++ b/src/WireMock/Serde/Type/SerdeTypeClass.php
@@ -263,7 +263,10 @@ class SerdeTypeClass extends SerdeTypeSingle
             $propertyValue = $serdeProp->instantiateAndConsumeData($data, $path);
             $refClass = new ReflectionClass($serdeProp->owningClassName);
             $refProp = $refClass->getProperty($serdeProp->name);
-            $refProp->setAccessible(true);
+            if (PHP_VERSION_ID < 80100)
+            {
+                $refProp->setAccessible(true);
+            }
             $refProp->setValue($object, $propertyValue);
         }
     }

--- a/test/WireMock/Integration/StubbingIntegrationTest.php
+++ b/test/WireMock/Integration/StubbingIntegrationTest.php
@@ -481,7 +481,10 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // same before asserting
         $matchingStrat = $stubMapping->getRequest()->getHeaders()['X-Munged-Date'];
         $matchValProp = new \ReflectionProperty($matchingStrat, 'matchingValue');
-        $matchValProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $matchValProp->setAccessible(true);
+        }
         $matchValProp->setValue($matchingStrat, 'now +0 seconds');
         assertThatTheOnlyMappingPresentIs($stubMapping);
     }
@@ -509,7 +512,10 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // same before asserting
         $matchingStrat = $stubMapping->getRequest()->getHeaders()['X-Munged-Date'];
         $matchValProp = new \ReflectionProperty($matchingStrat, 'matchingValue');
-        $matchValProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $matchValProp->setAccessible(true);
+        }
         $matchValProp->setValue($matchingStrat, 'now +0 seconds');
         assertThatTheOnlyMappingPresentIs($stubMapping);
     }
@@ -537,7 +543,10 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // same before asserting
         $matchingStrat = $stubMapping->getRequest()->getHeaders()['X-Munged-Date'];
         $matchValProp = new \ReflectionProperty($matchingStrat, 'matchingValue');
-        $matchValProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $matchValProp->setAccessible(true);
+        }
         $matchValProp->setValue($matchingStrat, 'now +0 seconds');
         assertThatTheOnlyMappingPresentIs($stubMapping);
     }
@@ -555,10 +564,16 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // mapping to be the same before asserting
         $matchingStrat = $stubMapping->getRequest()->getHeaders()['X-Munged-Date'];
         $matchValProp = new \ReflectionProperty($matchingStrat, 'matchingValue');
-        $matchValProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $matchValProp->setAccessible(true);
+        }
         $matchValProp->setValue($matchingStrat, 'now +3 days');
         $expectedOffsetProp = new \ReflectionProperty($matchingStrat, 'expectedOffset');
-        $expectedOffsetProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $expectedOffsetProp->setAccessible(true);
+        }
         $expectedOffsetProp->setValue($matchingStrat, null);
         assertThatTheOnlyMappingPresentIs($stubMapping);
     }
@@ -796,7 +811,10 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // have that defaulted to ANY. Our public API doesn't allow that modification, so we make some cheeky
         // changes via reflection before asserting.
         $methodProp = new \ReflectionProperty($stubMapping->getRequest(), 'method');
-        $methodProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $methodProp->setAccessible(true);
+        }
         $methodProp->setValue($stubMapping->getRequest(), 'ANY');
         assertThatTheOnlyMappingPresentIs($stubMapping);
         $customMatcher = $stubMapping->getRequest()->getCustomMatcher();
@@ -848,7 +866,10 @@ class StubbingIntegrationTest extends WireMockIntegrationTest
         // The stub mapping will be marked as persistent by the server, so we update the locally created version to
         // match before asserting
         $persistentProp = new \ReflectionProperty($stubMapping, 'persistent');
-        $persistentProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100)
+        {
+            $persistentProp->setAccessible(true);
+        }
         $persistentProp->setValue($stubMapping, true);
         assertThatTheOnlyMappingPresentIs($stubMapping);
     }

--- a/test/WireMock/Integration/TestClient.php
+++ b/test/WireMock/Integration/TestClient.php
@@ -27,7 +27,9 @@ class TestClient
 
         $result = $this->_makeTimedRequest($ch);
 
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $result;
     }
@@ -41,7 +43,9 @@ class TestClient
 
         $result = $this->_makeTimedRequest($ch);
 
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return $result;
     }


### PR DESCRIPTION
Moving to PHP 8.5 makes wiremock not happy with `curl_close` as it has been deprecated.

Please refer to: https://www.php.net/manual/en/function.curl-close.php